### PR TITLE
[PB-6602] encrypt preview and session key too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-crypto",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",

--- a/src/email-crypto/core.ts
+++ b/src/email-crypto/core.ts
@@ -56,10 +56,19 @@ export async function encryptEmailWithKey(
 ): Promise<EmailEncrypted> {
   try {
     const text = UTF8ToUint8(email.text);
+    const preview = UTF8ToUint8(email.preview);
 
     const encryptedText = await encryptSymmetrically(encryptionKey, text, aux);
     const encText = uint8ArrayToBase64(encryptedText);
-    return { encText };
+
+    const encryptedPreview = await encryptSymmetrically(encryptionKey, preview, aux);
+    const encPreview = uint8ArrayToBase64(encryptedPreview);
+
+
+    const encryptedAttachmentsSessionKey = await encryptSymmetrically(encryptionKey, email.attachmentsSessionKey, aux);
+    const encAttachmentsSessionKey = uint8ArrayToBase64(encryptedAttachmentsSessionKey);
+
+    return { encText, encPreview, encAttachmentsSessionKey };
   } catch (error) {
     throw new EmailSymmetricEncryptionError(error instanceof Error ? error.message : String(error));
   }
@@ -83,7 +92,14 @@ export async function decryptEmail(
     const textArray = await decryptSymmetrically(encryptionKey, encText, aux);
     const text = uint8ToUTF8(textArray);
 
-    return { text };
+    const encPreview = base64ToUint8Array(encEmail.encPreview);
+    const previewArray = await decryptSymmetrically(encryptionKey, encPreview, aux);
+    const preview = uint8ToUTF8(previewArray);
+
+    const encAttachementSessionKey = base64ToUint8Array(encEmail.encAttachmentsSessionKey);
+    const attachmentsSessionKey = await decryptSymmetrically(encryptionKey, encAttachementSessionKey, aux);
+
+    return { text, preview, attachmentsSessionKey};
   } catch (error) {
     throw new EmailSymmetricDecryptionError(error instanceof Error ? error.message : String(error));
   }

--- a/src/email-crypto/core.ts
+++ b/src/email-crypto/core.ts
@@ -64,7 +64,6 @@ export async function encryptEmailWithKey(
     const encryptedPreview = await encryptSymmetrically(encryptionKey, preview, aux);
     const encPreview = uint8ArrayToBase64(encryptedPreview);
 
-
     const encryptedAttachmentsSessionKey = await encryptSymmetrically(encryptionKey, email.attachmentsSessionKey, aux);
     const encAttachmentsSessionKey = uint8ArrayToBase64(encryptedAttachmentsSessionKey);
 
@@ -99,7 +98,7 @@ export async function decryptEmail(
     const encAttachementSessionKey = base64ToUint8Array(encEmail.encAttachmentsSessionKey);
     const attachmentsSessionKey = await decryptSymmetrically(encryptionKey, encAttachementSessionKey, aux);
 
-    return { text, preview, attachmentsSessionKey};
+    return { text, preview, attachmentsSessionKey };
   } catch (error) {
     throw new EmailSymmetricDecryptionError(error instanceof Error ? error.message : String(error));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export type PwdProtectedKey = {
 
 export type EmailEncrypted = {
   encText: string;
+  encPreview: string;
+  encAttachmentsSessionKey: string;
 };
 
 export type EmailAndSubjectEncrypted = EmailEncrypted & {
@@ -56,6 +58,8 @@ export type EmailAndSubjectEncrypted = EmailEncrypted & {
 
 export type Email = {
   text: string;
+  preview: string;
+  attachmentsSessionKey: Uint8Array;
 };
 
 export type EmailAndSubject = Email & {

--- a/tests/email-crypto/core.test.ts
+++ b/tests/email-crypto/core.test.ts
@@ -16,11 +16,15 @@ import { EmailSymmetricDecryptionError, InvalidInputEmail } from '../../src/emai
 describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'test email',
+    preview: 'email preview',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4,5,6,7,8]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'test email text',
     subject: 'test email subject',
+    preview: 'email preview',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4,5,6,7,8]),
   };
 
   const aux = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/email-crypto/core.test.ts
+++ b/tests/email-crypto/core.test.ts
@@ -17,14 +17,14 @@ describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'test email',
     preview: 'email preview',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4,5,6,7,8]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'test email text',
     subject: 'test email subject',
     preview: 'email preview',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4,5,6,7,8]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
   };
 
   const aux = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/email-crypto/hybridEmail.test.ts
+++ b/tests/email-crypto/hybridEmail.test.ts
@@ -27,11 +27,15 @@ import {
 describe('Test email crypto functions', async () => {
   const email: Email = {
     text: 'test email text',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'test email text',
     subject: 'test email subject',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const { secretKey: alicePrivateKeys, publicKey: alicePublicKeys } = await generateEmailKeys();
@@ -90,6 +94,8 @@ describe('Test email crypto functions', async () => {
       encryptedKey: encKey,
       encEmail: {
         encText: 'mock encrypted text',
+        encPreview: 'mock encryped preview',
+        encAttachmentsSessionKey: 'mock encrypted attachement session key',
       },
     };
 
@@ -98,6 +104,8 @@ describe('Test email crypto functions', async () => {
       encEmail: {
         encText: 'mock encrypted text',
         encSubject: 'mock encrypted subject',
+        encPreview: 'mock encryped preview',
+        encAttachmentsSessionKey: 'mock encrypted attachement session key',
       },
     };
 

--- a/tests/email-crypto/hybridEmail.test.ts
+++ b/tests/email-crypto/hybridEmail.test.ts
@@ -28,14 +28,14 @@ describe('Test email crypto functions', async () => {
   const email: Email = {
     text: 'test email text',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'test email text',
     subject: 'test email subject',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const { secretKey: alicePrivateKeys, publicKey: alicePublicKeys } = await generateEmailKeys();

--- a/tests/email-crypto/pwdProtectedEmail.test.ts
+++ b/tests/email-crypto/pwdProtectedEmail.test.ts
@@ -13,11 +13,15 @@ import { Email, EmailAndSubject, PwdProtectedEmail, PwdProtectedEmailAndSubject 
 describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const sharedSecret = 'test shared secret';

--- a/tests/email-crypto/pwdProtectedEmail.test.ts
+++ b/tests/email-crypto/pwdProtectedEmail.test.ts
@@ -14,14 +14,14 @@ describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const sharedSecret = 'test shared secret';

--- a/tests/email-crypto/pwdProtectedEmailCoreErrors.test.ts
+++ b/tests/email-crypto/pwdProtectedEmailCoreErrors.test.ts
@@ -27,14 +27,14 @@ describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const sharedSecret = 'test shared secret';

--- a/tests/email-crypto/pwdProtectedEmailCoreErrors.test.ts
+++ b/tests/email-crypto/pwdProtectedEmailCoreErrors.test.ts
@@ -26,11 +26,15 @@ describe('Test email crypto functions', () => {
 
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const sharedSecret = 'test shared secret';

--- a/tests/email-crypto/pwdProtectedEmailNobleErrors.test.ts
+++ b/tests/email-crypto/pwdProtectedEmailNobleErrors.test.ts
@@ -38,14 +38,14 @@ describe('Test email crypto functions', () => {
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
     preview: 'Hi Bib,',
-    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
+    attachmentsSessionKey: new Uint8Array([1, 2, 3, 4]),
   };
 
   const sharedSecret = 'test shared secret';

--- a/tests/email-crypto/pwdProtectedEmailNobleErrors.test.ts
+++ b/tests/email-crypto/pwdProtectedEmailNobleErrors.test.ts
@@ -37,11 +37,15 @@ describe('Test email crypto functions', () => {
 
   const email: Email = {
     text: 'Hi Bob, This is a test message. -Alice.',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const emailAndSubject: EmailAndSubject = {
     text: 'Hi Bob, This is a test message. -Alice.',
     subject: 'test subject',
+    preview: 'Hi Bib,',
+    attachmentsSessionKey: new Uint8Array([1,2,3,4]),
   };
 
   const sharedSecret = 'test shared secret';


### PR DESCRIPTION
## Description

Extend Email type to include preview and attachmentSessionKey, encrypt/decrypt them

## Checklist

- [x] Changes have been tested locally.
- [x] Unit tests have been written or updated as necessary.
- [x] The code adheres to the repository's coding standards.
- [ ] Relevant documentation has been added or updated.
- [x] No new warnings or errors have been introduced.
- [x] SonarCloud issues have been reviewed and addressed.
- [ ] QA Passed

## Testing Process

unit tests

## Additional Notes

should make the server code easier and prevent double decryption